### PR TITLE
Parse initValue as date

### DIFF
--- a/src/ng-quick-date.coffee
+++ b/src/ng-quick-date.coffee
@@ -65,7 +65,7 @@ app.directive "quickDatepicker", ['ngQuickDateDefaults', '$filter', '$sce', (ngQ
       scope.inputTime = null # Time inputted into the time text input field
       scope.invalid = true
       if typeof(attrs.initValue) == 'string'
-        ngModelCtrl.$setViewValue(attrs.initValue)
+        ngModelCtrl.$setViewValue(parseDateString(attrs.initValue))
       setCalendarDate()
       refreshView()
 
@@ -221,7 +221,7 @@ app.directive "quickDatepicker", ['ngQuickDateDefaults', '$filter', '$sce', (ngQ
 
     # DATA WATCHES
     # ==================================
-    
+
     # Called when the model is updated from outside the datepicker
     ngModelCtrl.$render = ->
       setCalendarDate(ngModelCtrl.$viewValue)


### PR DESCRIPTION
In 9ea32e2e2b0c668152011b52bc4d5901d33f6979 parsing the initValue (string) as a date has been removed.

For me this leads to a type error ("undefined is not a function") in line 258 when working with strings as initial values.
