### PR TITLE
Adding read-only mode where user cannot pick a date

### DIFF
--- a/src/ng-quick-date.coffee
+++ b/src/ng-quick-date.coffee
@@ -27,6 +27,7 @@ app.provider "ngQuickDateDefaults", ->
       defaultTime: null
       dayAbbreviations: ["Su", "M", "Tu", "W", "Th", "F", "Sa"],
       dateFilter: null
+      readOnly: false
       parseDateFunction: (str) ->
         seconds = Date.parse(str)
         if isNaN(seconds)
@@ -274,6 +275,8 @@ app.directive "quickDatepicker", ['ngQuickDateDefaults', '$filter', '$sce', (ngQ
       (show) ->
         if isFinite(show)
           scope.calendarShown = show
+        else if scope.readOnly
+          scope.calendarShown = false
         else
           scope.calendarShown = not scope.calendarShown
 


### PR DESCRIPTION
_Note:_ This is a re-create of https://github.com/adamalbrecht/ngQuickDate/pull/69 as that fork has been deleted. Also worth noting that **ngQuickDate seems to be failing 8 tests**, but that's already the case on master, not due to these changes.

Adding read-only option: `read-only="true"`

This makes the directive not trigger the popup, preventing the user from selecting a date.

See bottom form, data updates according to the model using $watch, but user cannot manually edit End Date.
![](http://i.imgur.com/M3Xe6Bm.png)
